### PR TITLE
:wrench: try with environment variable name

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -131,6 +131,3 @@ jobs:
       # register PyPI integration:
       # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # remove repository key to set the default to pypi (not test.pypi.org)
-          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
- somehow token cannot be fetched, see actions triggered by release `v0.4.0`:
https://github.com/biosustain/growthcurves/actions/runs/21708247433/job/62604911806

```bash
Status: Downloaded newer image for ghcr.io/pypa/gh-action-pypi-publish:release-v1
Error: Trusted publishing exchange failure: 
Token request failed: the server refused the request for the following reasons:

* `invalid-publisher`: valid token, but no corresponding publisher (Publisher with matching claims was not found)

This generally indicates a trusted publisher configuration error, but could
also indicate an internal error on GitHub or PyPI's part.


The claims rendered below are **for debugging purposes only**. You should **not**
use them to configure a trusted publisher unless they already match your expectations.

If a claim is not present in the claim set, then it is rendered as `MISSING`.

* `sub`: `repo:biosustain/growthcurves:ref:refs/tags/v0.4.0`
* `repository`: `biosustain/growthcurves`
* `repository_owner`: `biosustain`
* `repository_owner_id`: `5499849`
* `workflow_ref`: `biosustain/growthcurves/.github/workflows/cicd.yml@refs/tags/v0.4.0`
* `job_workflow_ref`: `biosustain/growthcurves/.github/workflows/cicd.yml@refs/tags/v0.4.0`
* `ref`: `refs/tags/v0.4.0`
* `environment`: `MISSING`

See https://docs.pypi.org/trusted-publishers/troubleshooting/ for more help.

```

to test