### PR TITLE
🔧 set use of spline OD weights to False per default

### DIFF
--- a/src/growthcurves/non_parametric.py
+++ b/src/growthcurves/non_parametric.py
@@ -239,7 +239,7 @@ def fit_spline(
     t,
     N,
     smooth="fast",
-    use_weights=True,
+    use_weights=False,
 ):
     """
     Calculate maximum specific growth rate using spline fitting.
@@ -254,7 +254,7 @@ def fit_spline(
                 - "fast": notebook auto-default rule mapped to lam
                 - "slow": GCV-selected smoothing (lam=None)
                 - float: manual lam value
-        use_weights: Whether to apply OD-dependent weighting (default: True)
+        use_weights: Whether to apply OD-dependent weighting (default: False)
 
     Returns:
         Dict with model parameters:
@@ -278,6 +278,7 @@ def fit_spline(
                 power=_SPLINE_GCV_WEIGHT_POWER,
             )
         else:
+            # Default in scipy.interpolate.make_smoothing_spline are uniform weights.
             w = np.ones_like(y_log, dtype=float)
 
         # Fit spline with selected smoothing mode/value.


### PR DESCRIPTION
Switch default to False as discussed in https://github.com/biosustain/growthcurves_app/pull/23

The default in scipy.interpolate.make_smoothing_spline are uniform weights.