### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,21 @@
 
 A Python package for fitting and analyzing microbial growth curves.
 
-Supports logistic, Gompertz, and Richards parametric models with automatic
-growth statistics extraction (specific growth rate, doubling time, phase
-boundaries) and non-parametric methods (spline fitting and sliding window).
+Supports logistic, Gompertz, Richards, and Baranyi parametric models with
+automatic growth statistics extraction (specific growth rate, doubling time,
+phase boundaries) and non-parametric methods (spline fitting and sliding window).
+
+## Web apps
+
+This package powers two browser-based apps for human-in-the-loop growth curve
+analysis, hosted at <https://biosustain.github.io/growthcurves_app/>:
+
+- **[MicroGrowth](https://thegrowthanalysisapp.streamlit.app/)** — analysis of
+  microtiter plate reader experiments, with support for multi-condition layouts
+  and interactive quality control.
+- **[AutoGrowth](https://autogrowth.streamlit.app/)** — analysis of mini-bioreactor
+  data (e.g. Pioreactor, Chi.Bio), built for continuous culture and real-time
+  monitoring.
 
 ## Installation
 
@@ -28,9 +40,10 @@ import numpy as np
 t = np.linspace(0, 24, 100)
 N = 0.01 + 1.5 / (1 + np.exp(-0.5 * (t - 10)))  # synthetic logistic data
 
-# Fit a parametric model and extract growth statistics
-fit_result = gc.parametric.fit_parametric(t, N, method="mech_logistic")
-stats = gc.inference.extract_stats(fit_result, t, N)
+# Fit a model and extract growth statistics in one call.
+# fit_model returns (fit_result, stats); it dispatches on the model name, so the
+# same entry point works for parametric and non-parametric methods alike.
+fit_result, stats = gc.fit_model(t, N, "mech_logistic")
 
 print(f"Max OD:               {stats['max_od']:.3f}")
 print(f"Specific growth rate: {stats['mu_max']:.4f} h⁻¹")
@@ -38,10 +51,7 @@ print(f"Doubling time:        {stats['doubling_time']:.2f} h")
 
 # Or use a non-parametric spline fit
 # smooth: "fast" (auto-default), "slow" (GCV), or a float (manual lambda)
-spline_fit = gc.non_parametric.fit_non_parametric(
-    t, N, method="spline", smooth="fast"
-)
-spline_stats = gc.inference.extract_stats(spline_fit, t, N)
+spline_fit, spline_stats = gc.fit_model(t, N, "spline", smooth="fast")
 
 print(f"\nSpline fit results:")
 print(f"Specific growth rate: {spline_stats['mu_max']:.4f} h⁻¹")
@@ -51,9 +61,9 @@ print(f"Doubling time:        {spline_stats['doubling_time']:.2f} h")
 giving output like:
 
 ```
-Max OD:               1.510
-Specific growth rate: 0.4422 h⁻¹
-Doubling time:        1.57 h
+Max OD:               1.554
+Specific growth rate: 0.4610 h⁻¹
+Doubling time:        1.50 h
 
 Spline fit results:
 Specific growth rate: 0.4247 h⁻¹
@@ -72,12 +82,12 @@ We use the formulations as stated in
 
 #### Mechanistic models (ODE-based)
 
-| Model          | Function                     | Parameters          |
-| -------------- | ---------------------------- | ------------------- |
-| Mech. Logistic | `models.mech_logistic_model` | mu, K, N0, y0       |
-| Mech. Gompertz | `models.mech_gompertz_model` | mu, K, N0, y0       |
-| Mech. Richards | `models.mech_richards_model` | mu, K, N0, beta, y0 |
-| Mech. Baranyi  | `models.mech_baranyi_model`  | mu, K, N0, h0, y0   |
+| Model          | Function                     | Parameters      |
+| -------------- | ---------------------------- | --------------- |
+| Mech. Logistic | `models.mech_logistic_model` | mu, K, N0       |
+| Mech. Gompertz | `models.mech_gompertz_model` | mu, K, N0       |
+| Mech. Richards | `models.mech_richards_model` | mu, K, N0, beta |
+| Mech. Baranyi  | `models.mech_baranyi_model`  | mu, K, N0, h0   |
 
 Mechanistic models are defined as ordinary differential equations (ODEs) and fitted using numerical integration.
 
@@ -131,7 +141,7 @@ When `smooth` is a float, higher values produce smoother curves and lower values
 
 ## Key features
 
-- **Parametric fitting** — fit logistic, Gompertz, or Richards models with automatic parameter estimation
+- **Parametric fitting** — fit logistic, Gompertz, Richards, or Baranyi models with automatic parameter estimation
 - **Non-parametric methods** — model-free growth rate estimation using:
   - **Spline fitting** — smoothing splines on log-transformed data with derivative-based growth rate calculation
   - **Sliding window** — moving window linear fits to log-transformed data


### PR DESCRIPTION
Updated the readme to reflect the following changes to the package:

1. Baranyi is now supported
2. Mechanistic models no longer fit a y0 parameter (users must baseline correct data before fitting)
3. Added link to the apps' website
4. Update the quick start to use the new 'fit_model' api
5. Update mechanistic models to fit in log space